### PR TITLE
Fix illegal default type parameters

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -175,7 +175,7 @@ pub struct Future<T, E=()> {
     read: bool
 }
 
-impl<T, E=()> Future<T, E>
+impl<T, E> Future<T, E>
     where T: Send + 'static,
           E: Send + 'static
 {


### PR DESCRIPTION
Not sure if this crate is abandoned or not, but it's going to be broken by an upcoming bugfix in rustc. This PR removes some default type parameters on impls that are not currently permitted by the language.
See https://github.com/rust-lang/rust/issues/36887 and rust-lang/rust#36894 for more details.
